### PR TITLE
feat: flb_read_from_file function to read and update config

### DIFF
--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -22,6 +22,7 @@
 
 #include <fluent-bit/flb_macros.h>
 #include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_format.h>
 
 /* Lib engine status */
 #define FLB_LIB_ERROR     -1
@@ -90,5 +91,9 @@ FLB_EXPORT flb_ctx_t *flb_context_get();
 
 FLB_EXPORT void flb_cf_context_set(struct flb_cf *cf);
 FLB_EXPORT struct flb_cf *flb_cf_context_get();
+
+/* read config file and update the ctx*/
+FLB_EXPORT struct flb_cf *flb_read_from_file(struct flb_cf *cf,
+                                        struct flb_config *config, char *file);
 
 #endif

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -849,3 +849,17 @@ struct flb_cf *flb_cf_context_get()
     cf = FLB_TLS_GET(flb_lib_active_cf_context);
     return cf;
 }
+
+struct flb_cf *flb_read_from_file(struct flb_cf *cf,
+                                        struct flb_config *config, char *file)
+{
+    int ret = -1;
+    cf = flb_cf_fluentbit_create(cf, file, NULL, 0);
+    ret = flb_config_load_config_format(config, cf);
+    if (ret != 0) {
+        return NULL;
+    }
+
+    config->cf_main = cf;
+    return cf;
+}

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -854,7 +854,7 @@ struct flb_cf *flb_read_from_file(struct flb_cf *cf,
                                         struct flb_config *config, char *file)
 {
     int ret = -1;
-    cf = flb_cf_fluentbit_create(cf, file, NULL, 0);
+    cf = flb_cf_create_from_file(cf, file);
     ret = flb_config_load_config_format(config, cf);
     if (ret != 0) {
         return NULL;


### PR DESCRIPTION
This adds the function `flb_read_from_file` that reads a config file from I/O and updates the fluent-bit context. With this code, the function is capable of reading and further parsing both `.conf` and `.yaml` files having the fluent-bit config. 

The function mainly takes inspiration from the internal functions used in reading a config file from the command arguments. The developed function is externally exported, thus can be used as other C-API functions of fluent-bit.